### PR TITLE
Added a version that uses typed arrays

### DIFF
--- a/spark-md5.array.js
+++ b/spark-md5.array.js
@@ -467,9 +467,9 @@
     };
 
     /**
-     * Performs the md5 hash on a binary string.
+     * Performs the md5 hash on a typed array.
      *
-     * @param {ArrayBuffer}  content The binary string
+     * @param {ArrayBuffer}  content The binary array
      * @param {Boolean} raw     True to get the raw result, false to get the hex result
      *
      * @return {String|Array} The result


### PR DESCRIPTION
readAsBinaryString is deprecated and IE10 doesn't have this function so I translated the code for use with typed arrays as I'm primarily using the code to hash files.

I left it as a separate file as it will only work in modern browsers - IE10, Chrome 9, Firefox 15, etc
