### PR TITLE
Add package.json to allow installing through NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "spark-md5",
+  "version": "0.0.4",
+  "description": "Lightning fast normal and incremental md5 for javascript",
+  "main": "spark-md5.js",
+  "directories": {
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:satazor/SparkMD5.git"
+  },
+  "keywords": [
+    "md5",
+    "fast",
+    "spark",
+    "incremental"
+  ],
+  "author": "André Cruz <andremiguelcruz@msn.com>",
+  "license": "WTFPL",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/satazor/SparkMD5/issues"
+  }
+}


### PR DESCRIPTION
I'm trying to use SparkMD5 with a project using browserify - having the package in npm would make things very easy for me (and anyone else who's a fan of npm).

See https://npmjs.org/doc/publish.html for how to publish the package on npm.
