### PR TITLE
Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Lightning fast normal and incremental md5 for javascript",
   "main": "spark-md5.js",
   "files": [
-    "spark-md5.js"  
+    "spark-md5.js",
+    "spark-md5.min.js"
   ],
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.1",
   "description": "Lightning fast normal and incremental md5 for javascript",
   "main": "spark-md5.js",
+  "files": [
+    "spark-md5.js"  
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
By adding the `files` property to package.json, we can tell npm which files to distribute. Currently, all the configuration files (`.editorconfig`, `.jshintrc`) and all the test files are distributed with npm. This increases the size of the npm distribution beyond what it needs to be.

npm will automatically include the `README.md` and `LICENSE` files for you, along with the `package.json` file.

This change reduces the distribution from 219kb to just over 25kb. That's almost a 90% saving!